### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Compile PDFs
         run: make
       - name: Publish PDFs to GitHub releases
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -20,11 +20,10 @@ jobs:
           files: |
             out/release/all.zip
       - name: Publish HTML to GitHub pages
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           branch: gh-pages
           folder: out/docs
           git-config-name: GitHub Pages Bot
           git-config-email: bot@example.com
-


### PR DESCRIPTION
This changes the default branch reference to `main` and thus fixes the GitHub Actions and deployments.

Don't forget to also enable GitHub Pages :)

![image](https://user-images.githubusercontent.com/28832235/136252847-4b6d4a42-4b3d-4aae-ac4f-1ea990c6d04c.png)
